### PR TITLE
🩹 Chore: 신청 테이블의 상태값 타입 변경 및 신청, 운친 응답 dto에 상태값 포함

### DIFF
--- a/server/src/main/java/com/ilchinjo/mainproject/domain/exercise/dto/ExerciseDetailResponseDto.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/exercise/dto/ExerciseDetailResponseDto.java
@@ -2,6 +2,7 @@ package com.ilchinjo.mainproject.domain.exercise.dto;
 
 import com.ilchinjo.mainproject.domain.address.dto.AddressResponseDto;
 import com.ilchinjo.mainproject.domain.exercise.entity.Category;
+import com.ilchinjo.mainproject.domain.exercise.entity.ExerciseStatus;
 import com.ilchinjo.mainproject.domain.exercise.entity.GenderType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,8 @@ public class ExerciseDetailResponseDto {
     private AddressResponseDto address;
 
     private Category category;
+
+    private ExerciseStatus exerciseStatus;
 
     private LocalDateTime createdAt;
 

--- a/server/src/main/java/com/ilchinjo/mainproject/domain/exercise/dto/ExerciseResponseDto.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/exercise/dto/ExerciseResponseDto.java
@@ -2,6 +2,7 @@ package com.ilchinjo.mainproject.domain.exercise.dto;
 
 import com.ilchinjo.mainproject.domain.address.dto.AddressResponseDto;
 import com.ilchinjo.mainproject.domain.exercise.entity.Category;
+import com.ilchinjo.mainproject.domain.exercise.entity.ExerciseStatus;
 import com.ilchinjo.mainproject.domain.exercise.entity.GenderType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -29,6 +30,8 @@ public class ExerciseResponseDto {
     private AddressResponseDto address;
 
     private Category category;
+
+    private ExerciseStatus exerciseStatus;
 
     private LocalDateTime createdAt;
 

--- a/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/dto/ProposalResponseDto.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/dto/ProposalResponseDto.java
@@ -2,6 +2,7 @@ package com.ilchinjo.mainproject.domain.proposal.dto;
 
 import com.ilchinjo.mainproject.domain.exercise.dto.ExerciseResponseDto;
 import com.ilchinjo.mainproject.domain.member.dto.MemberResponseDto;
+import com.ilchinjo.mainproject.domain.proposal.entity.ProposalStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,4 +16,5 @@ public class ProposalResponseDto {
     private Long proposalId;
     private ExerciseResponseDto exercise;
     private MemberResponseDto participant;
+    private ProposalStatus proposalStatus;
 }

--- a/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/dto/ProposalSimpleResponseDto.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/dto/ProposalSimpleResponseDto.java
@@ -1,7 +1,7 @@
 package com.ilchinjo.mainproject.domain.proposal.dto;
 
-import com.ilchinjo.mainproject.domain.exercise.dto.ExerciseResponseDto;
 import com.ilchinjo.mainproject.domain.member.dto.MemberResponseDto;
+import com.ilchinjo.mainproject.domain.proposal.entity.ProposalStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,4 +14,5 @@ import lombok.NoArgsConstructor;
 public class ProposalSimpleResponseDto {
     private Long proposalId;
     private MemberResponseDto participant;
+    private ProposalStatus proposalStatus;
 }

--- a/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/entity/Proposal.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/entity/Proposal.java
@@ -26,6 +26,7 @@ public class Proposal extends AuditingEntity {
     private Member participant;
 
     @Builder.Default
+    @Enumerated(EnumType.STRING)
     private ProposalStatus status = ProposalStatus.UNAPPROVED;
 
     public static Proposal createProposal(Exercise exercise, Member participant) {


### PR DESCRIPTION
제가 또 @ Enumerated(EnumType.STRING)를 빼먹었네요ㅠㅠ

저 부분을 적용하려면 테이블을 드랍하셔야 합니다. 없는 컬럼이 생기는건 update에서 적용이 되는데, 기존 값의 변경은 update에서 적용이 안되더라구요.

dto에도 상태값을 추가했습니다.