### PR TITLE
♻️ Refactor: 일부 엔티티에 updatedAt 수동 적용

### DIFF
--- a/server/src/main/java/com/ilchinjo/mainproject/domain/exercise/entity/Exercise.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/exercise/entity/Exercise.java
@@ -31,6 +31,9 @@ public class Exercise extends AuditingEntity {
 
     private LocalDateTime endAt;
 
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
     @Enumerated(EnumType.STRING)
     private GenderType genderType;
 
@@ -89,6 +92,7 @@ public class Exercise extends AuditingEntity {
         Optional.ofNullable(exercise.getCategory())
                 .ifPresent(category -> this.category = category);
         this.address = address;
+        this.updatedAt = LocalDateTime.now();
 
     }
 

--- a/server/src/main/java/com/ilchinjo/mainproject/domain/member/entity/Member.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/member/entity/Member.java
@@ -9,6 +9,7 @@ import com.ilchinjo.mainproject.global.audit.AuditingEntity;
 import lombok.*;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,6 +60,9 @@ public class Member extends AuditingEntity {
 
     @Builder.Default
     private int publicEvaluation = 20;
+
+    @Builder.Default
+    private LocalDateTime updatedAt = LocalDateTime.now();
 
     public void update(Member member, Address address) {
 


### PR DESCRIPTION
운친모집글의 경우 상태만 변경되어도 updatedAt이 바뀌는데 이는 의도한거랑 달라서 수동으로 적용되게 바꿨습니다.
멤버의 경우 updatedAt이 별로 활용이 안되어서 나중에 비밀번호 변경시 업데이트되도록 하면 좋을거같습니다.