### PR TITLE
✨  Feat: 시큐리티 config path 규칙 변경

### DIFF
--- a/server/src/main/java/com/ilchinjo/mainproject/global/security/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/security/config/SecurityConfiguration.java
@@ -58,33 +58,26 @@ public class SecurityConfiguration {
                 .and()
                 .authorizeRequests(authorize -> authorize
 
-                        .antMatchers(HttpMethod.POST, "/members").permitAll() // 회원 가입
-                        .antMatchers(HttpMethod.PATCH, "/members/**").hasRole("USER") // 회원 정보 수정
-                        .antMatchers(HttpMethod.GET, "/members/profiles").hasRole("USER") // 마이페이지 조회
-
-                        .antMatchers(HttpMethod.POST, "/exercises").hasRole("USER") // 운동 친구 모집 글 작성
-                        .antMatchers(HttpMethod.PATCH, "/exercises/**").hasRole("USER") // 운동 친구 모집 글 수정
-                        .antMatchers(HttpMethod.GET, "/exercises/**").permitAll() // 운동 친구 모집 글 조회
-                        .antMatchers(HttpMethod.DELETE, "/exercises/**").hasAnyRole("USER", "ADMIN") // 운동 친구 모집 글 삭제
-
-                        .antMatchers(HttpMethod.POST, "/*/reviews").hasRole("USER") // 리뷰 작성
-
-                        .antMatchers(HttpMethod.POST, "/exercises/*/comments").hasAnyRole("USER", "ADMIN") // 댓글 생성
-                        .antMatchers(HttpMethod.GET, "/exercises/*/comments").permitAll() // 댓글 조회
-                        .antMatchers(HttpMethod.DELETE, "/comments/**").hasAnyRole("USER", "ADMIN") // 댓글 삭제
-
-                        .antMatchers(HttpMethod.POST, "/comments/*/replies").hasAnyRole("USER", "ADMIN") // 대댓글 생성
-                        .antMatchers(HttpMethod.DELETE, "/replies/**").hasAnyRole("USER", "ADMIN") // 대댓글 삭제
-
                         .antMatchers(HttpMethod.GET, "/addresses").permitAll() // 주소 목록 조회
+                        .antMatchers("/addresses/**").hasRole("USER")
 
-                        .antMatchers(HttpMethod.POST, "/exercises/*/proposals").hasRole("USER") // 운동 모집 신청
+                        .antMatchers(HttpMethod.POST, "/members").permitAll() // 회원 가입
+                        .antMatchers("/members/**").hasRole("USER")
+
+                        .antMatchers(HttpMethod.GET, "/exercises/*").permitAll() // 운동 친구 모집 글 조회
+                        .antMatchers(HttpMethod.GET, "/exercises/*/comments").permitAll() // 댓글 조회
                         .antMatchers(HttpMethod.GET, "/exercises/*/proposals").permitAll() // 운동 모집 신청자 목록 조회
-                        .antMatchers(HttpMethod.POST, "/proposals/*/approvals").hasRole("USER") // 운동 모집 수락
+                        .antMatchers("/exercises/**").hasRole("USER")
 
-                        .antMatchers(HttpMethod.POST, "/images").hasRole("USER") // 이미지 등록
+                        .antMatchers("/comments/**").hasRole("USER")
 
-                        .anyRequest().permitAll()
+                        .antMatchers("/replies/**").hasRole("USER")
+
+                        .antMatchers("/proposals/**").hasRole("USER")
+
+                        .antMatchers("/images").hasRole("USER")
+
+                        .anyRequest().denyAll()
                 );
 
         return http.build();


### PR DESCRIPTION
전반적으로 회원권한을 요구하는 부분이 대부분이고 권한필요없음이 소수라서 이렇게 변경하였습니다. 일단 안되는 부분을 전반적으로 막고, 권한이 필요없는 부분을 앞에 배치하여 허용하게 하였습니다. 마찬가지로 모든 리퀘스트에 대해서도 전부다 막고, 괜찮은 부분만 열도록 했습니다.
이러한 방식을 화이트리스트 방식이라고 하더라구요.