### PR TITLE
✨ Feat: Access Token 만료 시에 Refresh Token을 통해 재발급하는 로직 구현

### DIFF
--- a/server/src/main/java/com/ilchinjo/mainproject/domain/auth/entity/RefreshToken.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,36 @@
+package com.ilchinjo.mainproject.domain.auth.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String token;
+
+    private RefreshToken(String email, String token) {
+        this.email = email;
+        this.token = token;
+    }
+
+    public static RefreshToken createToken(String email, String token) {
+        return new RefreshToken(email, token);
+    }
+
+    public void changeToken(String token) {
+        this.token = token;
+    }
+}

--- a/server/src/main/java/com/ilchinjo/mainproject/domain/auth/repository/RefreshTokenRepository.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.ilchinjo.mainproject.domain.auth.repository;
+
+import com.ilchinjo.mainproject.domain.auth.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByEmail(String email);
+}

--- a/server/src/main/java/com/ilchinjo/mainproject/global/security/config/SecurityConfiguration.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/security/config/SecurityConfiguration.java
@@ -1,5 +1,6 @@
 package com.ilchinjo.mainproject.global.security.config;
 
+import com.ilchinjo.mainproject.domain.auth.repository.RefreshTokenRepository;
 import com.ilchinjo.mainproject.domain.member.repository.MemberRepository;
 import com.ilchinjo.mainproject.global.security.filter.JwtAuthenticationFilter;
 import com.ilchinjo.mainproject.global.security.filter.JwtVerificationFilter;
@@ -8,7 +9,7 @@ import com.ilchinjo.mainproject.global.security.handler.MemberAuthenticationEntr
 import com.ilchinjo.mainproject.global.security.handler.MemberAuthenticationFailureHandler;
 import com.ilchinjo.mainproject.global.security.handler.MemberAuthenticationSuccessHandler;
 import com.ilchinjo.mainproject.global.security.jwt.JwtTokenizer;
-import com.ilchinjo.mainproject.global.security.utils.CustomAuthorityUtils;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -28,17 +29,12 @@ import java.util.List;
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfiguration {
 
     private final JwtTokenizer jwtTokenizer;
-    private final CustomAuthorityUtils authorityUtils;
     private final MemberRepository memberRepository;
-
-    public SecurityConfiguration(JwtTokenizer jwtTokenizer, CustomAuthorityUtils authorityUtils, MemberRepository memberRepository) {
-        this.jwtTokenizer = jwtTokenizer;
-        this.authorityUtils = authorityUtils;
-        this.memberRepository = memberRepository;
-    }
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -112,13 +108,13 @@ public class SecurityConfiguration {
 
             AuthenticationManager authenticationManager = builder.getSharedObject(AuthenticationManager.class);
 
-            JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, jwtTokenizer);
+            JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(authenticationManager, jwtTokenizer, refreshTokenRepository);
             jwtAuthenticationFilter.setFilterProcessesUrl("/auth/login");
 
             jwtAuthenticationFilter.setAuthenticationSuccessHandler(new MemberAuthenticationSuccessHandler(memberRepository));
             jwtAuthenticationFilter.setAuthenticationFailureHandler(new MemberAuthenticationFailureHandler());
 
-            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer, authorityUtils);
+            JwtVerificationFilter jwtVerificationFilter = new JwtVerificationFilter(jwtTokenizer);
 
             builder
                     .addFilter(jwtAuthenticationFilter)

--- a/server/src/main/java/com/ilchinjo/mainproject/global/security/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/security/filter/JwtAuthenticationFilter.java
@@ -93,8 +93,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
                         },
                         () -> {
                             RefreshToken token = RefreshToken.createToken(member.getEmail(), refreshToken);
-                            log.info("issueRefreshToken | save email: {}, token: {}", token.getEmail(), token.getToken());
                             refreshTokenRepository.save(token);
+                            log.info("issueRefreshToken | save email: {}, token: {}", token.getEmail(), token.getToken());
                         });
 
         return refreshToken;

--- a/server/src/main/java/com/ilchinjo/mainproject/global/security/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/security/filter/JwtAuthenticationFilter.java
@@ -1,11 +1,14 @@
 package com.ilchinjo.mainproject.global.security.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ilchinjo.mainproject.domain.auth.entity.RefreshToken;
+import com.ilchinjo.mainproject.domain.auth.repository.RefreshTokenRepository;
 import com.ilchinjo.mainproject.domain.member.entity.Member;
 import com.ilchinjo.mainproject.global.security.dto.LoginDto;
 import com.ilchinjo.mainproject.global.security.jwt.JwtTokenizer;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -20,11 +23,13 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
     private final JwtTokenizer jwtTokenizer;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @SneakyThrows
     @Override
@@ -78,6 +83,19 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String base64EncodedSecretKey = jwtTokenizer.encodeBase64SecretKey(jwtTokenizer.getSecretKey());
 
         String refreshToken = jwtTokenizer.generateRefreshToken(subject, expiration, base64EncodedSecretKey);
+
+        refreshTokenRepository.findByEmail(member.getEmail())
+                .ifPresentOrElse(
+                        r -> {
+                            r.changeToken(refreshToken);
+                            refreshTokenRepository.save(r);
+                            log.info("issueRefreshToken | change token");
+                        },
+                        () -> {
+                            RefreshToken token = RefreshToken.createToken(member.getEmail(), refreshToken);
+                            log.info("issueRefreshToken | save email: {}, token: {}", token.getEmail(), token.getToken());
+                            refreshTokenRepository.save(token);
+                        });
 
         return refreshToken;
     }

--- a/server/src/main/java/com/ilchinjo/mainproject/global/security/jwt/JwtTokenizer.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/security/jwt/JwtTokenizer.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
@@ -136,5 +137,21 @@ public class JwtTokenizer {
                 .getBody();
 
         return claims.get("memberId", Long.class);
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        String base64EncodedSecretKey = encodeBase64SecretKey(secretKey);
+        Key key = getKeyFromBase64EncodedKey(base64EncodedSecretKey);
+
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        UserDetails userDetails = memberDetailsService.loadUserByUsername(claims.getSubject());
+
+        return new UsernamePasswordAuthenticationToken(userDetails, token, userDetails.getAuthorities());
     }
 }

--- a/server/src/main/java/com/ilchinjo/mainproject/global/security/jwt/JwtTokenizer.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/security/jwt/JwtTokenizer.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
@@ -96,6 +97,14 @@ public class JwtTokenizer {
                 .setExpiration(expiration)
                 .signWith(key)
                 .compact();
+    }
+
+    public String reIssueAccessToken(Long memberId, Authentication authentication) {
+
+        String newAccessToken = generateAccessToken(memberId, authentication);
+        SecurityContextHolder.getContext().setAuthentication(getAuthentication(newAccessToken));
+
+        return newAccessToken;
     }
 
     public Jws<Claims> getClaims(String jws, String base64EncodedSecretKey) {

--- a/server/src/main/java/com/ilchinjo/mainproject/global/security/jwt/JwtTokenizer.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/security/jwt/JwtTokenizer.java
@@ -1,5 +1,7 @@
 package com.ilchinjo.mainproject.global.security.jwt;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ilchinjo.mainproject.domain.auth.entity.RefreshToken;
 import com.ilchinjo.mainproject.domain.auth.repository.RefreshTokenRepository;
 import com.ilchinjo.mainproject.global.security.userdetails.MemberDetailsService;
@@ -22,10 +24,7 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Slf4j
 @Component
@@ -171,6 +170,23 @@ public class JwtTokenizer {
                 .getBody();
 
         return claims.get("memberId", Long.class);
+    }
+
+    public Long parseMemberIdFromPayload(String jwt) {
+
+        HashMap<String, String> payloadMap;
+
+        try {
+            String[] splitJwt = jwt.split("\\.");
+            String payload = new String(Base64.getDecoder().decode(splitJwt[1].getBytes()));
+
+            payloadMap = new ObjectMapper().readValue(payload, HashMap.class);
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            return null;
+        }
+
+        return Long.valueOf(String.valueOf(payloadMap.get("memberId")));
     }
 
     public Authentication getAuthentication(String token) {


### PR DESCRIPTION
- 토큰의 재발급 과정은 Access Token이 만료됨을 전제로 합니다.
- 재발급 요청 시 Access Token과 Refresh Token을 함께 헤더에 담아서 전송해야 합니다.
- Access Token과 Refresh Token이 함께 재발급되며, 이전에 발급받은 Refresh Token은 이후의 검증에 사용할 수 없습니다.