### PR TITLE
🐛 Bug: 운동모집 글의 성별타입이 SAME일 때, 이성이 신청 못하게하는 로직 추가

### DIFF
--- a/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/service/ProposalServiceImpl.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/service/ProposalServiceImpl.java
@@ -2,6 +2,7 @@ package com.ilchinjo.mainproject.domain.proposal.service;
 
 import com.ilchinjo.mainproject.domain.exercise.entity.Exercise;
 import com.ilchinjo.mainproject.domain.exercise.entity.ExerciseStatus;
+import com.ilchinjo.mainproject.domain.exercise.entity.GenderType;
 import com.ilchinjo.mainproject.domain.exercise.service.ExerciseService;
 import com.ilchinjo.mainproject.domain.member.entity.Member;
 import com.ilchinjo.mainproject.domain.member.service.MemberService;
@@ -34,9 +35,11 @@ public class ProposalServiceImpl implements ProposalService {
     @Override
     public ProposalResponseDto saveProposal(Long exerciseId, Long participantId) {
         Exercise findExercise = exerciseService.findVerifiedExercise(exerciseId);
+        Member participant = memberService.findVerifiedMember(participantId);
         checkExerciseValid(findExercise);
         checkSelfPropose(findExercise, participantId);
         checkDuplicatedPropose(findExercise, participantId);
+        checkMatchedGenderType(findExercise, participant);
         Member findParticipant = memberService.findVerifiedMember(participantId);
         return mapper.entityToResponseDto(
                 proposalRepository.save(Proposal.createProposal(findExercise, findParticipant))
@@ -92,6 +95,14 @@ public class ProposalServiceImpl implements ProposalService {
         for (Proposal proposal : proposals) {
             if (Objects.equals(proposal.getParticipant().getMemberId(), memberId)) {
                 throw new BusinessLogicException(ExceptionCode.CANT_DUPLICATED_PROPOSAL);
+            }
+        }
+    }
+
+    private void checkMatchedGenderType(Exercise exercise, Member participant) {
+        if (exercise.getGenderType().equals(GenderType.SAME)) {
+            if (!Objects.equals(exercise.getHost().getGender(), participant.getGender())) {
+                throw new BusinessLogicException(ExceptionCode.GENDER_TYPE_NOT_MATCHED);
             }
         }
     }

--- a/server/src/main/java/com/ilchinjo/mainproject/global/exception/ExceptionCode.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/exception/ExceptionCode.java
@@ -11,6 +11,7 @@ public enum ExceptionCode {
     COMMENT_NOT_FOUND(404, "Comment not found"),
     CANT_PROPOSE_MYSELF(422, "Cant propose myself"),
     CANT_DUPLICATED_PROPOSAL(422, "Cant duplicated proposal"),
+    GENDER_TYPE_NOT_MATCHED(422, "Gender type is not matched"),
     START_TIME_IS_PASSED(422, "Start time is passed"),
     END_TIME_IS_NOT_PASSED(422, "End time is not passed"),
     START_TIME_IS_LATER_THAN_END_TIME(422, "Start time is later than end time"),


### PR DESCRIPTION
운동 모집글의 성별 타입이 SAME일 때, 이성의 신청을 막는 로직을 추가하였습니다.