### PR TITLE
🐛 Fix: 신청 전체 조회 시 중복되어서 조회되는 문제 수정

### DIFF
--- a/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/repository/ProposalRepository.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/repository/ProposalRepository.java
@@ -1,7 +1,12 @@
 package com.ilchinjo.mainproject.domain.proposal.repository;
 
+import com.ilchinjo.mainproject.domain.exercise.entity.Exercise;
 import com.ilchinjo.mainproject.domain.proposal.entity.Proposal;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ProposalRepository extends JpaRepository<Proposal, Long> {
+
+    List<Proposal> findAllByExercise(Exercise exercise);
 }

--- a/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/service/ProposalServiceImpl.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/domain/proposal/service/ProposalServiceImpl.java
@@ -50,7 +50,7 @@ public class ProposalServiceImpl implements ProposalService {
     public List<ProposalSimpleResponseDto> findProposals(Long exerciseId) {
         Exercise findExercise = exerciseService.findVerifiedExercise(exerciseId);
 
-        return mapper.entitiesToSimpleResponseDtoList(findExercise.getProposals());
+        return mapper.entitiesToSimpleResponseDtoList(proposalRepository.findAllByExercise(findExercise));
     }
 
     @Override

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
       hibernate:
         format_sql: true # SQL 쿼리 pretty print
         dialect: org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect # 이게 포함되어있어야 jts Geometry -> DB GEOMETRY type으로 생성됩니다.
-    show-sql: true # SQL 쿼리 출력
+    #    show-sql: true # SQL 쿼리 출력
     open-in-view: true
     defer-datasource-initialization: true # hibernate의 auto schema creation(ddl-auto) 이후에 schema.sql, data.sql실행
   sql:


### PR DESCRIPTION
Eager 로딩에서 fetch join되면서 중복된 데이터가 들어간걸로 판단됩니다.
나중에 전체적으로 lazy로딩으로 전환해야될거같습니다.
```java
@Override
public List<ProposalSimpleResponseDto> findProposals(Long exerciseId) {
    Exercise findExercise = exerciseService.findVerifiedExercise(exerciseId);

    return mapper.entitiesToSimpleResponseDtoList(findExercise.getProposals());
}
```
위 코드 인 경우
```sql
select
    proposals0_.exercise_id as exercise5_6_0_,
    proposals0_.proposal_id as proposal1_6_0_,
    proposals0_.proposal_id as proposal1_6_1_,
    proposals0_.created_at as created_2_6_1_,
    proposals0_.updated_at as updated_3_6_1_,
    proposals0_.exercise_id as exercise5_6_1_,
    proposals0_.participant_id as particip6_6_1_,
    proposals0_.status as status4_6_1_,
    member1_.member_id as member_i1_4_2_,
    member1_.created_at as created_2_4_2_,
    member1_.updated_at as updated_3_4_2_,
    member1_.address_id as address_9_4_2_,
    member1_.email as email4_4_2_,
    member1_.gender as gender5_4_2_,
    member1_.nickname as nickname6_4_2_,
    member1_.password as password7_4_2_,
    member1_.public_evaluation as public_e8_4_2_,
    address2_.address_id as address_1_0_3_,
    address2_.created_at as created_2_0_3_,
    address2_.updated_at as updated_3_0_3_,
    address2_.center_point as center_p4_0_3_,
    address2_.eupmyeondong as eupmyeon5_0_3_,
    address2_.multi_polygon as multi_po6_0_3_,
    address2_.sido as sido7_0_3_,
    address2_.sigungu as sigungu8_0_3_,
    image3_.image_id as image_id1_3_4_,
    image3_.created_at as created_2_3_4_,
    image3_.updated_at as updated_3_3_4_,
    image3_.exercise_id as exercise8_3_4_,
    image3_.filename as filename4_3_4_,
    image3_.filesize as filesize5_3_4_,
    image3_.original_filename as original6_3_4_,
    image3_.owner_id as owner_id9_3_4_,
    image3_.profiled_member_id as profile10_3_4_,
    image3_.remote_path as remote_p7_3_4_ 
from
    proposal proposals0_ 
left outer join
    member member1_ 
        on proposals0_.participant_id=member1_.member_id 
left outer join
    address address2_ 
        on member1_.address_id=address2_.address_id 
left outer join
    image image3_ 
        on member1_.member_id=image3_.profiled_member_id 
where
    proposals0_.exercise_id=68
```


반면
```java
@Override
public List<ProposalSimpleResponseDto> findProposals(Long exerciseId) {
    Exercise findExercise = exerciseService.findVerifiedExercise(exerciseId);

    return mapper.entitiesToSimpleResponseDtoList(proposalRepository.findAllByExercise(findExercise));
}
```
위 코드인 경우
```sql
select
    proposal0_.proposal_id as proposal1_6_,
    proposal0_.created_at as created_2_6_,
    proposal0_.updated_at as updated_3_6_,
    proposal0_.exercise_id as exercise5_6_,
    proposal0_.participant_id as particip6_6_,
    proposal0_.status as status4_6_ 
from
    proposal proposal0_ 
where
    proposal0_.exercise_id=68
```