### PR TITLE
#322 ♻️  Refactor: 쿠키설정 조정

### DIFF
--- a/server/src/main/java/com/ilchinjo/mainproject/global/security/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/com/ilchinjo/mainproject/global/security/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import com.ilchinjo.mainproject.global.security.jwt.JwtTokenizer;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -58,11 +59,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         response.setHeader("Authorization", "Bearer " + accessToken);
 
         ResponseCookie cookie = ResponseCookie.from("Refresh", refreshToken)
-                .domain("aroundexercise.com")
                 .maxAge(17 * 24 * 60 * 60)
-                .path("/")
+                .path("/auth/")
                 .secure(true)
-                .sameSite("None")
+                .sameSite(Cookie.SameSite.STRICT.attributeValue())
                 .httpOnly(true)
                 .build();
         response.setHeader("Set-Cookie", cookie.toString());


### PR DESCRIPTION
sameSite옵션을 Strict로 변경했습니다. CSRF공격을 예방하기 위해 변경하였습니다.

도메인 옵션은 삭제하였습니다. 이렇게 될 경우, 요청을 보낸곳의 도메인으로 맞춰서 보내주게됩니다.
개발편의성을 위해서 그렇게 수정하였고,
도메인을 맞춰서 보내준다고 하더라도, 따로 아이디비밀번호를 아는것이 아니면 공격을 받을 염려는 없다고 생각하여 그렇게 하였습니다.

path설정은 저렇게 하면 /auth/**요청에만 쿠키를 보내는것이 테스트로 확인됐습니다. 다만, 크롬개발자탭의 application -> cookie에서는 더이상 보이지 않게 됩니다. 쿠키의 존재확인은 auth관련 요청시 Network탭에서 request cookie를 보는걸로 확인가능합니다.
해당부분은 개발자도구에서 쿠키를 보거나 지우는것이 불가능한 점에서 많이 불편하긴 합니다. 이부분에 대해 의견 부탁드려요.